### PR TITLE
Adding in deserialize traits to AssetInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,19 @@ name = "cw-asset"
 version = "2.0.0"
 dependencies = [
  "cosmwasm-std",
+ "cw-storage-plus",
  "cw20",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
+dependencies = [
+ "cosmwasm-std",
  "schemars",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ repository = "https://github.com/mars-protocol/cw-asset"
 [dependencies]
 cosmwasm-std = "1.0"
 cw20 = "0.13"
+cw-storage-plus = "0.13"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }


### PR DESCRIPTION
DO NOT MERGE. Left to do:
- Write tests
- Fix compilation error regarding to temp value reference

In progress PR. Needed so that `AssetInfo` can be used as a key in a cosmwasm Map.