### PR TITLE
Implement `AssetInfoKey` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,10 +138,22 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "cosmwasm-std",
+ "cw-storage-plus",
  "cw20",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw-storage-plus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648b1507290bbc03a8d88463d7cd9b04b1fa0155e5eef366c4fa052b9caaac7a"
+dependencies = [
+ "cosmwasm-std",
  "schemars",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cw-asset"
 description = "Helper library for interacting with Cosmos assets (SDK coins and CW20 tokens)"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["larry <larry@delphidigital.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
@@ -10,5 +10,6 @@ repository = "https://github.com/mars-protocol/cw-asset"
 [dependencies]
 cosmwasm-std = "1.0"
 cw20 = "0.13"
+cw-storage-plus = "0.13"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,166 @@
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+use cosmwasm_std::{StdError, StdResult};
+use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
+
+use crate::{AssetInfo, AssetInfoUnchecked};
+
+/// TODO: add docs
+#[derive(Clone, Debug, PartialEq)]
+pub struct AssetInfoKey(pub Vec<u8>);
+
+macro_rules! impl_from {
+    ($structname: ty) => {
+        impl From<$structname> for AssetInfoKey {
+            fn from(info: $structname) -> Self {
+                Self(info.to_string().into_bytes())
+            }
+        }
+    }
+}
+
+impl_from!(AssetInfo);
+impl_from!(&AssetInfo);
+
+impl TryFrom<AssetInfoKey> for AssetInfoUnchecked {
+    type Error = StdError;
+
+    fn try_from(key: AssetInfoKey) -> Result<Self, Self::Error> {
+        let info_str = String::from_utf8(key.0)?;
+        AssetInfoUnchecked::from_str(&info_str)
+    }
+}
+
+impl<'a> PrimaryKey<'a> for AssetInfoKey {
+    type Prefix = ();
+    type SubPrefix = ();
+    type Suffix = Self;
+    type SuperSuffix = Self;
+
+    fn key(&self) -> Vec<Key> {
+        vec![Key::Ref(&self.0)]
+    }
+}
+
+impl<'a> Prefixer<'a> for AssetInfoKey {
+    fn prefix(&self) -> Vec<Key> {
+        vec![Key::Ref(&self.0)]
+    }
+}
+
+impl KeyDeserialize for AssetInfoKey {
+    type Output = Self;
+
+    #[inline(always)]
+    fn from_vec(value: Vec<u8>) -> StdResult<Self::Output> {
+        Ok(Self(value))
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cosmwasm_std::testing::mock_dependencies;
+    use cosmwasm_std::{Addr, Order};
+    use cw_storage_plus::Map;
+
+    fn mock_keys() -> (AssetInfo, AssetInfo) {
+        (
+            AssetInfo::cw20(Addr::unchecked("mars_token")),
+            AssetInfo::native("uosmo"),
+        )
+    }
+
+    #[test]
+    fn casting() {
+        let info = AssetInfo::native("uosmo");
+        let key = AssetInfoKey("native:uosmo".to_string().into_bytes());
+
+        assert_eq!(AssetInfoKey::from(&info), key);
+        assert_eq!(AssetInfoKey::from(info.clone()), key);
+
+        assert_eq!(AssetInfoUnchecked::try_from(key).unwrap(), info.into());
+    }
+
+    #[test]
+    fn storage_key_works() {
+        let mut deps = mock_dependencies();
+        let (key_1, key_2) = &mock_keys();
+        let map: Map<AssetInfoKey, u64> = Map::new("map");
+
+        map.save(deps.as_mut().storage, key_1.into(), &42069).unwrap();
+        map.save(deps.as_mut().storage, key_2.into(), &69420).unwrap();
+
+        assert_eq!(map.load(deps.as_ref().storage, key_1.into()).unwrap(), 42069);
+        assert_eq!(map.load(deps.as_ref().storage, key_2.into()).unwrap(), 69420);
+
+        let items = map
+            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .map(|item| { item.unwrap() })
+            .collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], (key_1.into(), 42069));
+        assert_eq!(items[1], (key_2.into(), 69420));
+    }
+
+    #[test]
+    fn composite_key_works() {
+        let mut deps = mock_dependencies();
+        let (key_1, key_2) = &mock_keys();
+        let map: Map<(AssetInfoKey, Addr), u64> = Map::new("map");
+
+        map.save(
+            deps.as_mut().storage,
+            (key_1.into(), Addr::unchecked("larry")),
+            &42069,
+        )
+        .unwrap();
+
+        map.save(
+            deps.as_mut().storage,
+            (key_1.into(), Addr::unchecked("jake")),
+            &69420,
+        )
+        .unwrap();
+
+        map.save(
+            deps.as_mut().storage,
+            (key_2.into(), Addr::unchecked("larry")),
+            &88888,
+        )
+        .unwrap();
+
+        map.save(
+            deps.as_mut().storage,
+            (key_2.into(), Addr::unchecked("jake")),
+            &123456789,
+        )
+        .unwrap();
+
+        let items = map
+            .prefix(key_1.into())
+            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .map(|item| { item.unwrap() })
+            .collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], (Addr::unchecked("jake"), 69420));
+        assert_eq!(items[1], (Addr::unchecked("larry"), 42069));
+
+        let items = map
+            .prefix(key_2.into())
+            .range(deps.as_ref().storage, None, None, Order::Ascending)
+            .map(|item| { item.unwrap() })
+            .collect::<Vec<_>>();
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0], (Addr::unchecked("jake"), 123456789));
+        assert_eq!(items[1], (Addr::unchecked("larry"), 88888));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-//! A unified representation of various types of Cosmos fungible assets, and helper functions for  
+//! A unified representation of various types of Cosmos fungible assets, and helper functions for
 //! interacting with them
 //!
 //! ## Basic usage
@@ -74,7 +74,7 @@
 //! ```rust
 //! use cosmwasm_std::{Api, StdResult};
 //! use cw_asset::{Asset, AssetUnchecked};
-//! 
+//!
 //! const ACCEPTED_DENOMS: &[&str] = &["uatom", "uosmo", "uluna"];
 //!
 //! fn validate_deposit(api: &dyn Api, asset_unchecked: AssetUnchecked) -> StdResult<()> {
@@ -85,6 +85,7 @@
 mod asset;
 mod asset_info;
 mod asset_list;
+mod key;
 
 pub use asset::*;
 pub use asset_info::*;


### PR DESCRIPTION
Allows `AssetInfo` to be used as storage key in maps:

```rust
use cosmwasm_std::testing::mock_dependencies;
use cw_asset::{AssetInfo, AssetInfoKey};
use cw_storage_plus::Map;

let deps = mock_dependencies();
let map: Map<AssetInfoKey, u64> = Map::new("map");

map.save(
    deps.as_mut().storage,
    AssetInfo::native("uosmo").into(), // cast AssetInfo into AssetInfoKey
    &12345,
)
.unwrap();
```