### PR TITLE
feat: Added CW1155 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,10 +138,11 @@ dependencies = [
 
 [[package]]
 name = "cw-asset"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw1155",
  "cw20",
  "schemars",
  "serde",
@@ -160,14 +161,26 @@ dependencies = [
 
 [[package]]
 name = "cw-utils"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "babd2c090f39d07ce5bf2556962305e795daa048ce20a93709eb591476e4a29e"
+checksum = "9dbaecb78c8e8abfd6b4258c7f4fbeb5c49a5e45ee4d910d3240ee8e1d714e1b"
 dependencies = [
  "cosmwasm-std",
  "schemars",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "cw1155"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42197c9a0fd844653177009125f24157e486578289327a3781923e427a8f9bbc"
+dependencies = [
+ "cosmwasm-std",
+ "cw-utils",
+ "schemars",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cw-asset"
 description = "Helper library for interacting with Cosmos assets (SDK coins and CW20 tokens)"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["larry <larry@delphidigital.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
@@ -10,6 +10,7 @@ repository = "https://github.com/mars-protocol/cw-asset"
 [dependencies]
 cosmwasm-std = "1.0"
 cw20 = "0.13"
+cw1155 = "0.13"
 cw-storage-plus = "0.13"
 schemars = "0.8.1"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/src/asset.rs
+++ b/src/asset.rs
@@ -531,6 +531,12 @@ mod tests {
             AssetUnchecked::from_str(s).unwrap(),
             AssetUnchecked::cw20("mock_token", 12345u128),
         );
+
+        let s = "cw1155:mock_contract:mock_token:12345";
+        assert_eq!(
+            AssetUnchecked::from_str(s).unwrap(),
+            AssetUnchecked::cw1155("mock_contract", "mock_token", 12345u128),
+        );
     }
 
     #[test]
@@ -540,6 +546,9 @@ mod tests {
 
         let asset = Asset::cw20(Addr::unchecked("mock_token"), 88888u128);
         assert_eq!(asset.to_string(), String::from("cw20:mock_token:88888"));
+
+        let asset = Asset::cw1155(Addr::unchecked("mock_contract"), "mock_token", 88888u128);
+        assert_eq!(asset.to_string(), String::from("cw1155:mock_contract:mock_token:88888"));
     }
 
     #[test]


### PR DESCRIPTION
Added CW1155 support addressing https://github.com/mars-protocol/cw-asset/issues/10
```
test result: ok. 32 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests cw-asset

running 30 tests
```