### PR TITLE
AssetInfo implementations

### DIFF
--- a/src/asset_info.rs
+++ b/src/asset_info.rs
@@ -621,7 +621,7 @@ mod test {
 
         assert_eq!(
             vec![
-                // ("native3".to_string(), 10), - out of bound
+                // ("native3".to_string(), 30), - out of bound
                 ("native2".to_string(), 20),
                 ("native1".to_string(), 10)
             ],


### PR DESCRIPTION
This pull request would add some useful implementations to `AssetInfo`:
- Added `#[derive(Eq, PartialOrd, Ord, Hash)]` to `AssetInfoBase<T: AddressLike>` allowing to use `AssetInfoBase` as key for both `HashMap` and `BTreeMap`;
- Implemented `fn inner()` for `AssetInfo` which return the inner `cw20 addr` or `denom` wrapped within;
- `Prefix` and `Suffix` types have been changed from `()` - `()` to `String` - `String` on `PrimaryKey` implementation for `AssetInfo`. This allow to iterate over  a `Map<AssetInfo, T>` by prefix that can be `cw20:` or `native:` (colon is required to match with the first `key` generated in `fn key()` on `PrimaryKey` implementation);
- Tests have been created to assert these implementations.